### PR TITLE
'transparent' value validation

### DIFF
--- a/src/Caliburn.Micro.Extensions.WIN8/AppManifestHelper.cs
+++ b/src/Caliburn.Micro.Extensions.WIN8/AppManifestHelper.cs
@@ -75,6 +75,11 @@ namespace Caliburn.Micro
 
         private static Windows.UI.Color ToColor(string hexValue)
         {
+            // if 'transparent' is entered in the app manifest, return Windows.UI.Colors.Transparent
+            // in order to prevent parsing failures
+            if (hexValue == "transparent")
+                return Windows.UI.Colors.Transparent;
+                
             hexValue = hexValue.Replace("#", string.Empty);
 
             // some loose validation (not bullet-proof)

--- a/src/Caliburn.Micro.Extensions.WIN8/AppManifestHelper.cs
+++ b/src/Caliburn.Micro.Extensions.WIN8/AppManifestHelper.cs
@@ -77,7 +77,7 @@ namespace Caliburn.Micro
         {
             // if 'transparent' is entered in the app manifest, return Windows.UI.Colors.Transparent
             // in order to prevent parsing failures
-            if (hexValue == "transparent")
+            if (String.Equals(hexValue, "transparent", StringComparison.OrdinalIgnoreCase))
                 return Windows.UI.Colors.Transparent;
                 
             hexValue = hexValue.Replace("#", string.Empty);


### PR DESCRIPTION
You need to enter the value `transparent` as the background color in the app manifest to make your logos background transparent. If you do so, the settings service will throw a parse exception once you enter a settings flyout. This fix checks if you entered that value and returns a `Transparent` color object.
